### PR TITLE
feat: ErrorBoundary

### DIFF
--- a/packages/client/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/client/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,41 @@
+import React, { PureComponent, FC, ReactNode } from 'react'
+import { ErrorBoundaryProps, ErrorBoundaryState } from './types'
+
+const ErrorMsg: FC<{ error: Error }> = ({ error }) => {
+  return (
+    <div>
+      <p>Что-то пошло не так...</p>
+      <p>{error.message}</p>
+    </div>
+  )
+}
+
+class ErrorBoundary extends PureComponent<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = {
+    error: null,
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error }
+  }
+
+  render(): ReactNode {
+    const { error } = this.state
+    const { children, ErrorComponent } = this.props
+
+    if (error) {
+      return ErrorComponent ? (
+        <ErrorComponent error={error} />
+      ) : (
+        <ErrorMsg error={error} />
+      )
+    }
+
+    return children
+  }
+}
+
+export default ErrorBoundary

--- a/packages/client/src/components/ErrorBoundary/types.ts
+++ b/packages/client/src/components/ErrorBoundary/types.ts
@@ -1,0 +1,10 @@
+import { ComponentType, ReactNode } from 'react'
+
+export interface ErrorBoundaryProps {
+  children: ReactNode
+  ErrorComponent?: ComponentType<{ error: Error }>
+}
+
+export interface ErrorBoundaryState {
+  error: Error | null
+}


### PR DESCRIPTION
https://linear.app/memory-game/issue/MEM-39/nastroit-obrabotku-oshibok-vnutri-«detej»-react-komponentov


Добавлен класс-компонент ErrorBoundary для обработки ошибок в компонентах, можно передавать в props кастомную заглушку на случай ошибки, иначе, по умолчанию, вместо обёрнутого компонента отрисуется сообщение об ошибке.